### PR TITLE
Расширить возможности Яндекс загрузчика для скачивания и распаковки z…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,4 +175,5 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 
-.vscode
+.vscode/
+.notrack/

--- a/autoloader/loader_utils.py
+++ b/autoloader/loader_utils.py
@@ -2,35 +2,63 @@ import requests
 
 
 class FileLoader:
-    def __init__(self, file_repo, yandex_resource_meta_endp):
+    def __init__(self, file_repo, yandex_resource_meta_endp, yandex_resource_download_endp):
         self.file_repo = file_repo
         self.yandex_resource_meta_endp = yandex_resource_meta_endp
+        self.yandex_resource_download_endp = yandex_resource_download_endp
 
     def download_from_yandex(self, link: str):
-        if link.startswith("https://disk.yandex.ru"):
-            params = {"public_key": link}
-            with requests.get(self.yandex_resource_meta_endp, params=params, stream=True) as response:
-                response.raise_for_status()
-                parsed_response = response.json()
-        else:
-            raise Exception("link isn't yandex or formatted worng")
-        
-        if parsed_response["type"] == "file":
-            if parsed_response["mime_type"] == "video/mp4":
-                resource_metadata = {
-                    "name": parsed_response["name"],
-                    "format": "mp4",
-                    "file": parsed_response["file"],
-                }
+        if not (link.startswith("https://disk.yandex.ru") or link.startswith("disk.yandex.ru")):
+            raise Exception("неверная ссылка. (должна быть в виде 'disk.yandex.ru...')")
 
-        dl_file_path = self.file_repo / f'{resource_metadata["name"]}.{resource_metadata["format"]}'
-        with requests.get(resource_metadata["file"], stream=True) as response:
+        params = {"public_key": link}
+
+        with requests.get(self.yandex_resource_meta_endp, params=params) as response:
             response.raise_for_status()
-            with open(self.file_repo / f'{resource_metadata["name"]}.{resource_metadata["format"]}', 'wb') as f:
-                for chunk in response.iter_content(chunk_size=8192):
-                    f.write(chunk)
-        
-        if dl_file_path.exists():
-            return dl_file_path
+            resource_metadata = response.json()
+
+        if resource_metadata["type"] == "file" and resource_metadata["mime_type"].split("/")[0] == "video":
+            file_metadata = {
+                "name": resource_metadata["name"],
+                "format": resource_metadata["mime_type"].split("/")[1],
+                "file": resource_metadata["file"],
+            }
+
+            dl_file_path = self.file_repo / f'{file_metadata["name"]}.{file_metadata["format"]}'
+            
+            with requests.get(file_metadata["file"], stream=True) as response:
+                response.raise_for_status()
+                with open(self.file_repo / f'{file_metadata["name"]}.{file_metadata["format"]}', 'wb') as f:
+                    for chunk in response.iter_content(chunk_size=8192):
+                        f.write(chunk)
+            
+            if not dl_file_path.exists():
+                raise Exception("path to downloaded file does not exist")
+
+        elif  resource_metadata["type"] == "dir":
+            with requests.get(self.yandex_resource_download_endp, params=params) as response:
+                response.raise_for_status()
+                dl_link = response.json()["href"]
+            with requests.get(dl_link, stream=True) as resp:
+                resp.raise_for_status()
+                with open(f"{self.file_repo / resource_metadata["name"]}.zip", 'wb') as f:
+                    for chunk in resp.iter_content(chunk_size=8192):
+                        f.write(chunk)
+            dl_file_path = self.file_repo / f"{resource_metadata["name"]}.zip"
+            if not dl_file_path.exists():
+                raise Exception("path to downloaded file does not exist")
+
         else:
-            raise Exception("path to downloaded file does not exist")
+            with requests.get(self.yandex_resource_download_endp, params=params) as response:
+                response.raise_for_status()
+                dl_link = response.json()["href"]
+            with requests.get(dl_link, stream=True) as resp:
+                resp.raise_for_status()
+                with open(self.file_repo / f"{resource_metadata["name"]}.{resource_metadata["mime_type"].split("/")[1]}", 'wb') as f:
+                    for chunk in resp.iter_content(chunk_size=8192):
+                        f.write(chunk)
+            dl_file_path = self.file_repo / f"{resource_metadata["name"]}.{resource_metadata["mime_type"].split("/")[1]}"
+            if not dl_file_path.exists():
+                raise Exception("path to downloaded file does not exist")
+
+        return dl_file_path

--- a/autoloader/views.py
+++ b/autoloader/views.py
@@ -23,8 +23,9 @@ def index(request):
 def download_file(request):
     network_disk = settings.STORAGE_PATH
     file_loader = FileLoader(
-        settings.DOWNLOADS_PATH,
-        settings.YA_RES_META_ENDP,
+        file_repo=settings.DOWNLOADS_PATH,
+        yandex_resource_download_endp=settings.YANDEX_RESOURCE_DOWNLOAD_ENDP,
+        yandex_resource_meta_endp=settings.YANDEX_RESOURCE_METADATA_ENDP,
     )
     sourcelink = request.POST["sourcelink"]
     destdir = network_disk / request.POST["destdir"]

--- a/project/settings.py
+++ b/project/settings.py
@@ -123,6 +123,7 @@ STATIC_URL = 'static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # Custom Autoloader settings
-STORAGE_PATH = Path("Z:")
 DOWNLOADS_PATH = BASE_DIR / "autoloader" / "downloads"
-YA_RES_META_ENDP = r"""https://cloud-api.yandex.net/v1/disk/public/resources"""
+STORAGE_PATH = Path("Z:")
+YANDEX_RESOURCE_DOWNLOAD_ENDP = r"""https://cloud-api.yandex.net/v1/disk/public/resources/download"""
+YANDEX_RESOURCE_METADATA_ENDP = r"""https://cloud-api.yandex.net/v1/disk/public/resources"""


### PR DESCRIPTION
…ip-файлов, папок, изображений и пр. (#4)

На данный момент с Яндекса мы можем качать только `mp4` файлы. Их API позволяет скачивать и папки в виде архивов, и архивы, изображения, видео в другом формате и т.д.

В рамках этого тикета допишем `/autoloader/loader_utils.py` до полноценного состояния, т.е. чтобы можно было скачать всё, что позволяет скачать Яндекс API.