### PR TITLE
Добавить скачивание видео с ВКонтакте (#15)

### DIFF
--- a/autoloader/loader_utils.py
+++ b/autoloader/loader_utils.py
@@ -1,4 +1,4 @@
-from autoloader.tasks import dl_yandex_dir
+import autoloader.tasks as tasks
 
 
 class FileLoader:
@@ -7,11 +7,10 @@ class FileLoader:
         self.yandex_resource_meta_endp = yandex_resource_meta_endp
         self.yandex_resource_download_endp = yandex_resource_download_endp
 
-    def download_from_yandex(self, link: str, dir: str):
-        if not link.startswith(("https://disk.yandex.ru", "disk.yandex.ru")):
-            raise Exception("неверная ссылка. (должна быть в виде 'disk.yandex.ru...')")
+    def download(self, link: str, dir: str):
+        if link.startswith(("https://disk.yandex.ru", "disk.yandex.ru")):
+            tasks.dl_yandex_dir(link, self.yandex_resource_meta_endp, self.yandex_resource_download_endp, dir, self.file_repo)
+        elif link.startswith(("https://vk.com", "https://vkvideo.ru")):
+            tasks.dl_vk_video(link, dir, self.file_repo)
 
-
-        dl_yandex_dir(link, self.yandex_resource_meta_endp, self.yandex_resource_download_endp, dir, self.file_repo)
-        
         return None

--- a/autoloader/tasks.py
+++ b/autoloader/tasks.py
@@ -1,8 +1,29 @@
 import os
+from pathlib import Path
+import requests
 import shutil
 import zipfile
+
 from huey.contrib.djhuey import task
-import requests
+from yt_dlp import YoutubeDL
+
+
+@task()
+def dl_vk_video(link, dir, dls):
+    ydl_opts = {
+        "paths": {
+            "home": str(dls),
+        }
+    }
+    with YoutubeDL(ydl_opts) as ydl:
+        info = ydl.extract_info(link, download=True)
+        name = Path(info["requested_downloads"][0]["filename"])
+        ext = Path(info["requested_downloads"][0]["ext"])
+        ptd = name.parent / f"brodude.{ext}"
+        os.rename(name, ptd)
+    
+    shutil.move(ptd, dir, copy_function=shutil.copy2)  # TODO: если в конечном пункте уже существует файл или директория с таким именем, таск упадёт с ошибкой!
+
 
 
 @task()
@@ -65,4 +86,3 @@ def dl_yandex_dir(link, yandex_resource_meta_endp, yandex_resource_download_endp
     shutil.move(dl_file_path, dir, copy_function=shutil.copy2)  # TODO: если в конечном пункте уже существует файл или директория с таким именем, таск упадёт с ошибкой!
 
     return None
-

--- a/autoloader/views.py
+++ b/autoloader/views.py
@@ -33,7 +33,7 @@ def download_file(request):
         "destdir": destdir,
     }
     
-    file_loader.download_from_yandex(link=sourcelink, dir=destdir)
+    file_loader.download(link=sourcelink, dir=destdir)
     
     return render(
         request,


### PR DESCRIPTION
ВКонтакте один из основных источников видео наших пользователей. К счастью, существует мощная активно поддерживаемая утилита `yt-dlp`, в которой реализовано скачивание видео из ВК всеми вообразимыми способами.

В рамках этого тикета надо заэмбеддить `yt-dlp` для скачивания видео из ВК.